### PR TITLE
fix(docs): fix menu name to param-case

### DIFF
--- a/src/ui/atoms/menu-list/usage.mdx
+++ b/src/ui/atoms/menu-list/usage.mdx
@@ -1,5 +1,5 @@
 ---
-name: menuList
+name: menu-list
 category: atoms
 package: 'woly'
 ---

--- a/src/ui/molecules/input-password/usage.mdx
+++ b/src/ui/molecules/input-password/usage.mdx
@@ -1,5 +1,5 @@
 ---
-name: inputPassword
+name: input-password
 category: atoms
 package: 'woly'
 ---


### PR DESCRIPTION
Fix menu name to param-case in documentation