### PR TITLE
[FRNT-370] Implement Heading component

### DIFF
--- a/src/lib/box-styles.tsx
+++ b/src/lib/box-styles.tsx
@@ -5,6 +5,7 @@ export const Global = styled.div`
   --woly-const-m: 6px;
   --woly-main-level: 3;
   --woly-line-height: 24px;
+  font-family: 'Helvetica Neue';
 
   [data-variant='primary'] {
     --woly-background: #b0a3f4;

--- a/src/ui/atoms/heading/index.tsx
+++ b/src/ui/atoms/heading/index.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import styled, { StyledComponent } from 'styled-components';
+import { Variant } from 'lib/types';
+
+/**
+ * --woly-font-size
+ * --woly-label-color
+ * --woly-line-height
+ */
+
+interface HeadingProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
+  children: React.ReactNode;
+  size?: 1 | 2 | 3;
+  weight?: 'regular' | 'medium';
+}
+
+const map = (properties: HeadingProps & Variant) => ({
+  'data-size': properties.size || 1,
+  'data-variant': properties.variant || 'default',
+  'data-weight': properties.weight || 'medium',
+});
+
+export const Heading = styled.span.attrs(map)`
+  color: var(--woly-color, #000000);
+  font-size: 24px;
+  line-height: 30px;
+  font-weight: 500;
+  &[data-size='2'] {
+    font-size: 21px;
+    line-height: 27px;
+  }
+  &[data-size='3'] {
+    font-size: 18px;
+    line-height: 24px;
+  }
+  &[data-weight='regular'] {
+    font-weight: 400;
+  }
+` as StyledComponent<'label', Record<string, unknown>, HeadingProps & Variant>;

--- a/src/ui/atoms/heading/usage.mdx
+++ b/src/ui/atoms/heading/usage.mdx
@@ -1,0 +1,42 @@
+---
+name: heading
+category: atoms
+package: 'woly'
+---
+
+import { Playground, block } from 'box-styles'
+import { Heading } from './index';
+
+Heading component is used as a header of page.
+
+### Example
+
+<Playground direction="vertical">
+  <Heading size={1}>HeaderLarge</Heading>
+  <div>
+    <Heading size={2}>HeaderSmall,</Heading>
+    <Heading size={2} weight="regular">
+      HeaderSmall
+    </Heading>
+  </div>
+  <div>
+    <Heading size={3}>Subhead,</Heading>
+    <Heading size={3} weight="regular">
+      Subhead
+    </Heading>
+  </div>
+</Playground>
+
+### Kinds
+
+| Name      | Description                                             |
+| --------- | ------------------------------------------------------- |
+| `Heading` | Base heading. Useful for creating a new kind of heading |
+
+### Props
+
+| Name      | Type                   | Default     | Description                           |
+| --------- | ---------------------- | ----------- | ------------------------------------- |
+| `weight`  | `'regular' ӏ 'medium'` | `'medium'`  | Font weight of Heading                |
+| `size`    | `1 ӏ 2 ӏ 3`            | `'1'`       | Size of Heading                       |
+| `variant` | `string`               | `'default'` | Variant prop to style Input component |

--- a/src/ui/atoms/index.ts
+++ b/src/ui/atoms/index.ts
@@ -2,6 +2,7 @@ export { Button } from './button';
 export { ButtonFloating } from './button-floating';
 export { ButtonIcon } from './button-icon';
 export { Chip } from './chip';
+export { Heading } from './heading';
 export { Input } from './input';
 export { Label } from './label';
 export { List } from './list';


### PR DESCRIPTION
Implement Heading component. In example there is no visual difference between `weight` of text in comparison with design system because font-family is not set .
https://liberty-base.atlassian.net/browse/FRNT-370