### PR TITLE
fix(stylelint): correct config to work properly with vscode-stylelint…

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -5,10 +5,12 @@
     "stylelint-config-rational-order"
   ],
   "rules": {
+    "order/properties-order": [[], { "severity": "error" }],
     "plugin/rational-order": [
       true,
       {
-        "empty-line-between-groups": true
+        "empty-line-between-groups": true,
+        "severity": "error"
       }
     ],
     "no-descending-specificity": null


### PR DESCRIPTION
VSCode plugin for stylelint was constantly throwing error  `Error: severity property of a stylelint warning must be either 'error' or 'warning', but it was 'ignore`. I searched for a solution and came across [this comment](https://github.com/constverum/stylelint-config-rational-order/issues/13#issuecomment-522421878) in Github. It worked like a charm.