### PR TITLE
[FRNT-447] [FRNT-449] Fix chip padding and icon

### DIFF
--- a/src/lib/global.ts
+++ b/src/lib/global.ts
@@ -82,7 +82,7 @@ export const Global = styled.div`
   --woly-border-width: 1.5px;
   --woly-rounding: 3px;
 
-  --woly-line-height: 24px;
+  --woly-line-height: calc(24px - 2 * var(--woly-border-width));
   --woly-font-size: 15px;
 
   --woly-background: hsla(var(--bw-1000), 1);

--- a/src/woly/atoms/button-icon/index.tsx
+++ b/src/woly/atoms/button-icon/index.tsx
@@ -23,9 +23,10 @@ const ButtonIconBase: React.FC<Props & Priority> = ({
     onClick={onClick}
     role="button"
     type="button"
+    data-component
     {...p}
   >
-    <span data-icon>{icon}</span>
+    <span data-icon="button-icon">{icon}</span>
   </button>
 );
 
@@ -46,7 +47,7 @@ export const ButtonIcon = styled(ButtonIconBase)`
   border-radius: var(--woly-rounding);
   outline: none;
 
-  [data-icon] {
+  [data-icon='button-icon'] {
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/woly/atoms/chip/index.tsx
+++ b/src/woly/atoms/chip/index.tsx
@@ -41,55 +41,80 @@ const ChipBase: React.FC<ChipProps & Priority> = ({
       data-outlined={outlined}
       data-priority={priority}
     >
-      {leftIcon && (
-        <div data-icon="chip-visual-block" onClick={onClick} onKeyDown={onKeyDown}>
-          {leftIcon}
+      <div data-content>
+        {leftIcon && (
+          <div data-icon="chip-visual-block" onClick={onClick} onKeyDown={onKeyDown}>
+            {leftIcon}
+          </div>
+        )}
+        <div
+          data-text="chip-text-content"
+          onClick={onClick}
+          onKeyDown={onKeyDown}
+          role={chipRole}
+          tabIndex={chipTabIndex}
+        >
+          {text}
         </div>
-      )}
-      <div
-        data-text="chip-text-content"
-        onClick={onClick}
-        onKeyDown={onKeyDown}
-        role={chipRole}
-        tabIndex={chipTabIndex}
-      >
-        {text}
+        {rightIcon && (
+          <div data-icon="chip-action-block" data-size-none>
+            {rightIcon}
+          </div>
+        )}
       </div>
-      {rightIcon && <div data-icon="chip-action-block">{rightIcon}</div>}
+      <div data-background />
     </div>
   );
 };
 
 export const Chip = styled(ChipBase)`
-  ${box}
   --local-shape-color: var(--woly-shape-default);
   --local-icon-size: var(--woly-line-height);
   --local-text-color: var(--woly-shape-text-default);
   --local-border-color: var(--woly-shape-default);
+  --local-line-height: calc(var(--woly-line-height) + 2 * var(--woly-border-width));
+  position: relative;
 
-  display: flex;
-  align-items: center;
-
-  box-sizing: border-box;
-
-  color: var(--local-text-color);
   font-size: var(--woly-font-size);
 
-  background-color: var(--local-shape-color);
-  border: var(--woly-border-width) solid var(--local-border-color);
-  border-radius: var(--woly-rounding);
-  outline: none;
+  [data-content] {
+    ${box}
+
+    display: flex;
+    align-items: center;
+
+    box-sizing: border-box;
+  }
+
+  [data-background] {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+
+    background-color: var(--local-shape-color);
+    border: var(--woly-border-width) solid var(--local-border-color);
+    border-radius: var(--woly-rounding);
+    outline: none;
+  }
 
   [data-text] {
+    z-index: 1;
+
     display: flex;
     flex: 1;
 
-    line-height: var(--woly-line-height);
+    color: var(--local-text-color);
+
+    line-height: var(--local-line-height);
 
     outline: none;
   }
 
   [data-icon] {
+    z-index: 1;
+
     display: flex;
     flex-shrink: 0;
     align-items: center;
@@ -107,6 +132,9 @@ export const Chip = styled(ChipBase)`
   [data-icon='chip-visual-block'] {
     width: var(--local-icon-size);
     height: var(--local-icon-size);
+
+    color: var(--local-text-color);
+
     svg {
       width: 100%;
       height: 100%;

--- a/src/woly/elements/box/index.tsx
+++ b/src/woly/elements/box/index.tsx
@@ -1,38 +1,45 @@
 import { css } from 'styled-components';
 
 export const box = css`
-  --local-vertical: calc(
-    1px * var(--woly-component-level) * var(--woly-main-level) - var(--woly-border-width)
-  );
+  --local-vertical: calc(1px * var(--woly-component-level) * var(--woly-main-level));
   --local-horizontal: calc(
-    var(--woly-const-m) + (1px * var(--woly-main-level)) + var(--local-vertical) -
-      var(--woly-border-width)
+    var(--woly-const-m) + (1px * var(--woly-main-level)) + var(--local-vertical)
   );
   --local-gap: calc(1px * var(--woly-component-level) * var(--woly-main-level));
   --local-compensate: var(--local-vertical);
+  --local-component: var(--woly-const-m);
 
   & > * {
-    padding-top: var(--local-vertical);
-    padding-bottom: var(--local-vertical);
+    padding: var(--local-vertical) var(--local-horizontal);
   }
-
-  & > :first-child {
-    padding-left: var(--local-horizontal);
-  }
-
-  & > :last-child {
-    padding-right: var(--local-horizontal);
-  }
-
-  & > [data-icon]:first-child {
+  & > [data-icon]:first-child:not(:only-child) {
+    padding-right: 0;
     padding-left: var(--local-compensate);
   }
-  & > [data-icon]:last-child {
-    padding-right: var(--local-compensate);
+  & > [data-icon]:only-child {
+    padding: var(--local-vertical);
   }
-
   & > :not(:first-child) {
     padding-left: var(--local-gap);
+  }
+  & > [data-icon]:last-child:not(:only-child) {
+    padding: 0;
+  }
+  & > [data-icon]:last-child:not(:only-child) > * {
+    padding-top: var(--local-vertical);
+    padding-right: var(--local-compensate);
+    padding-bottom: var(--local-vertical);
+  }
+  & > [data-icon]:last-child:not(:only-child) > [data-component] {
+    margin: var(--local-component) var(--local-component) var(--local-component) auto;
+    padding: 0;
+  }
+  & > [data-size-none]:last-child:not(:only-child) {
+    margin: 0 var(--local-vertical) 0 0;
+  }
+
+  & > [data-size-none]:last-child:not(:only-child) > [data-component] {
+    margin: 0;
   }
 `;
 


### PR DESCRIPTION
 Fix chip padding and icon:

- Rewrite box model, remove subtraction of --woly-border-width from box
- Fix construction of Chip, now it's made by two parts - content and background. Background stretches for full width/height of content. It's made for the purpose => **border** of Chip stays inside of content height/width.

-FRNT-447
-FRNT-449