### PR TITLE
[FRNT-595] fix Loader

### DIFF
--- a/build/builder.js
+++ b/build/builder.js
@@ -98,7 +98,15 @@ function getPlugins(name, { isEsm = false } = {}) {
       },
     }),
     typescript: typescript({ tsconfig: 'tsconfig.json' }),
-    reactSvg: reactSvg(),
+    reactSvg: reactSvg({
+      svgo: {
+        plugins: [
+          {
+            removeViewBox: false,
+          },
+        ],
+      },
+    }),
   };
 }
 

--- a/src/static/icons/spinner.svg
+++ b/src/static/icons/spinner.svg
@@ -1,3 +1,3 @@
 <svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="50" cy="50" r="45" strokeWidth="10" fill="#000" />
+<circle cx="50" cy="50" r="45" stroke-width="10" stroke="#000" />
 </svg>


### PR DESCRIPTION
- В Loader svgo удаляет stroke-width потому что не указан цвет stroke
- svgo по умолчанию удаляет viewBox, что ломает все наши иконки т.к. все они рассчитаны на то что viewBox проставлен